### PR TITLE
Refactor a lot of stuff

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -32,7 +32,7 @@ def get_weather(woeid, unit, format, timeout=None):
     if r.status_code != 200:
         return 'HTTP error: %s' % r.status_code
 
-    s = BeautifulSoup(r.text)
+    s = BeautifulSoup(r.text, 'html.parser')
 
     data = {}
 


### PR DESCRIPTION
When we get an exception during weather-getting, the exception name is displayed in the output, and the exception message (but not the traceback) is printed to stderr as long as it is not the same kind of exception that was printed most recently. Hopefully, this means that if you lose your internet connection for a while, your .xsession-errors won't be spammed with tracebacks.

I've done only minimal testing. In particular, one of us should verify that it still works with Python 2.7 before merging this.