### PR TITLE
Changed shebang to use python3.

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import argparse
 from functools import partial
@@ -26,6 +26,7 @@ def arrow_direction(degrees):
     degrees = round(float(degrees) / 45)
     index = int(degrees) % 8
     return directions[index]
+
 
 def get_weather(woeid, unit, format, timeout=None):
     url = BASE_WEATHER_URL + urllib.parse.urlencode({


### PR DESCRIPTION
I ran into trouble using the latest fix, as lines 99-100 use python 3 specific syntax (namely, `print(next(stdin), end='')`). Changing the shebang to explicitly call python 3 resolved the issue.